### PR TITLE
Implement two check methods for smart sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,16 @@ Heimnetz -> Netzwerk -> Netzwerkeinstellungen ->  Heimnetzfreigaben -> Zugriff f
 
 ### Methods
 
-| Name                 | Description                            |
-|----------------------|----------------------------------------|
-| `connection_status`  | WAN connection status.                 |
-| `connection_uptime`  | WAN connection uptime in seconds.      |
-| `device_uptime`      | Device uptime in seconds.              |
-| `downstream_max`     | Maximum downstream.                    |
-| `upstream_max`       | Maximum upstream.                      |
-| `downstream_current` | Current downstream.                    |
-| `upstream_current`   | Current upstream.                      |
-| `interface_update`   | Update state.                          |
-| `smart_thermometer`  | Current temperature of the thermostat. |
+| Name                 | Description                                                  |
+|----------------------|--------------------------------------------------------------|
+| `connection_status`  | WAN connection status.                                       |
+| `connection_uptime`  | WAN connection uptime in seconds.                            |
+| `device_uptime`      | Device uptime in seconds.                                    |
+| `downstream_max`     | Maximum downstream.                                          |
+| `upstream_max`       | Maximum upstream.                                            |
+| `downstream_current` | Current downstream.                                          |
+| `upstream_current`   | Current upstream.                                            |
+| `interface_update`   | Update state.                                                |
+| `smart_thermometer`  | Current temperature of a radiator thermostat.                |
+| `smart_socketpower`  | Current power consumption of a socket switch.                |
+| `smart_socketenergy` | Total power consumption of the last year of a socket switch. |

--- a/cmd/check_fritz/check_smart.go
+++ b/cmd/check_fritz/check_smart.go
@@ -63,3 +63,105 @@ func CheckSmartThermometer(aI ArgumentInformation) {
 		fmt.Print("UNKNWON - Not able to calculate maximum downstream\n")
 	}
 }
+
+func CheckSmartSocketPower(aI ArgumentInformation) {
+	soapReq := fritz.NewSoapRequest(aI.Username, aI.Password, aI.Hostname, aI.Port, "/upnp/control/x_homeauto", "X_AVM-DE_Homeauto", "GetGenericDeviceInfos")
+	fritz.AddSoapRequestVariable(&soapReq, fritz.NewSoapRequestVariable("NewIndex", strconv.Itoa(aI.Index)))
+
+	err := fritz.DoSoapRequest(&soapReq)
+
+	if HandleError(err) {
+		return
+	}
+
+	var resp = fritz.GetSmartDeviceInfoResponse{}
+
+	err = fritz.HandleSoapRequest(&soapReq, &resp)
+
+	if HandleError(err) {
+		return
+	}
+
+	currentPower, err := strconv.ParseFloat(resp.NewMultimeterPower, 64)
+
+	if HandleError(err) {
+		return
+	}
+
+	currentPower = currentPower / 100.0
+
+	GlobalReturnCode = exitOk
+
+	if thresholds.CheckUpper(aI.Warning, currentPower) {
+		GlobalReturnCode = exitWarning
+	}
+
+	if thresholds.CheckUpper(aI.Critical, currentPower) {
+		GlobalReturnCode = exitCritical
+	}
+
+	output := "- " + resp.NewProductName + " " + resp.NewFirmwareVersion + " - " + resp.NewDeviceName + " " + resp.NewPresent + " " + fmt.Sprintf("%.2f", currentPower) + " W"
+
+	switch GlobalReturnCode {
+	case exitOk:
+		fmt.Print("OK " + output + "\n")
+	case exitWarning:
+		fmt.Print("WARNING " + output + "\n")
+	case exitCritical:
+		fmt.Print("CRITICAL " + output + "\n")
+	default:
+		GlobalReturnCode = exitUnknown
+		fmt.Print("UNKNWON - Not able to fetch socket power\n")
+	}
+}
+
+func CheckSmartSocketEnergy(aI ArgumentInformation) {
+	soapReq := fritz.NewSoapRequest(aI.Username, aI.Password, aI.Hostname, aI.Port, "/upnp/control/x_homeauto", "X_AVM-DE_Homeauto", "GetGenericDeviceInfos")
+	fritz.AddSoapRequestVariable(&soapReq, fritz.NewSoapRequestVariable("NewIndex", strconv.Itoa(aI.Index)))
+
+	err := fritz.DoSoapRequest(&soapReq)
+
+	if HandleError(err) {
+		return
+	}
+
+	var resp = fritz.GetSmartDeviceInfoResponse{}
+
+	err = fritz.HandleSoapRequest(&soapReq, &resp)
+
+	if HandleError(err) {
+		return
+	}
+
+	currentEnergy, err := strconv.ParseFloat(resp.NewMultimeterEnergy, 64)
+
+	if HandleError(err) {
+		return
+	}
+
+	currentEnergy = currentEnergy / 1000.0
+
+	GlobalReturnCode = exitOk
+
+	if thresholds.CheckUpper(aI.Warning, currentEnergy) {
+		GlobalReturnCode = exitWarning
+	}
+
+	if thresholds.CheckUpper(aI.Critical, currentEnergy) {
+		GlobalReturnCode = exitCritical
+	}
+
+	output := "- " + resp.NewProductName + " " + resp.NewFirmwareVersion + " - " + resp.NewDeviceName + " " + resp.NewPresent + " " + fmt.Sprintf("%.2f", currentEnergy) + " kWh"
+
+	switch GlobalReturnCode {
+	case exitOk:
+		fmt.Print("OK " + output + "\n")
+	case exitWarning:
+		fmt.Print("WARNING " + output + "\n")
+	case exitCritical:
+		fmt.Print("CRITICAL " + output + "\n")
+	default:
+		GlobalReturnCode = exitUnknown
+		fmt.Print("UNKNWON - Not able to fetch socket energy\n")
+	}
+}

--- a/cmd/check_fritz/main.go
+++ b/cmd/check_fritz/main.go
@@ -103,6 +103,10 @@ func main() {
 		CheckInterfaceUpdate(aI)
 	case "smart_thermometer":
 		CheckSmartThermometer(aI)
+	case "smart_socketpower":
+		CheckSmartSocketPower(aI)
+	case "smart_socketenergy":
+		CheckSmartSocketEnergy(aI)
 	default:
 		fmt.Println("Unknown method.")
 		GlobalReturnCode = exitUnknown


### PR DESCRIPTION
This implements two new check methods for smart sockets. One to check
the current power consumption in watts (smart_socketpower) and one to
check the total power consumption over the last year in kWh
(socket_powerenergy).

refs #2