### PR TITLE
Fix wrong error message in CheckSmartThermometer

### DIFF
--- a/cmd/check_fritz/check_smart.go
+++ b/cmd/check_fritz/check_smart.go
@@ -60,6 +60,6 @@ func CheckSmartThermometer(aI ArgumentInformation) {
 		fmt.Print("CRITICAL " + output + "\n")
 	default:
 		GlobalReturnCode = exitUnknown
-		fmt.Print("UNKNWON - Not able to calculate maximum downstream\n")
+		fmt.Print("UNKNWON - Not able to calculate thermostat temperature\n")
 	}
 }


### PR DESCRIPTION
This fixes a copy & paste mistake in CheckSmartThermometer regarding the
error message.