### PR TITLE
Fix wrong new line statement in output

### DIFF
--- a/cmd/check_fritz/check_downstream.go
+++ b/cmd/check_fritz/check_downstream.go
@@ -120,7 +120,7 @@ func CheckDownstreamCurrent(aI ArgumentInformation) {
 		}
 	}
 
-	output := " - Current Downstream: " + fmt.Sprintf("%.2f", downstream) + " Mbit/s \n " + perfData.GetPerformanceDataAsString()
+	output := " - Current Downstream: " + fmt.Sprintf("%.2f", downstream) + " Mbit/s " + perfData.GetPerformanceDataAsString()
 
 	switch GlobalReturnCode {
 	case exitOk:

--- a/cmd/check_fritz/check_upstream.go
+++ b/cmd/check_fritz/check_upstream.go
@@ -118,7 +118,7 @@ func CheckUpstreamCurrent(aI ArgumentInformation) {
 		}
 	}
 
-	output := " - Current Upstream: " + fmt.Sprintf("%.2f", upstream) + " Mbit/s \n " + perfData.GetPerformanceDataAsString()
+	output := " - Current Upstream: " + fmt.Sprintf("%.2f", upstream) + " Mbit/s " + perfData.GetPerformanceDataAsString()
 
 	switch GlobalReturnCode {
 	case exitOk:


### PR DESCRIPTION
In the methods downstream_current and upstream_current is a wrong new
line statement. This removes the new line statement.