### PR TITLE
Fix golint import path in CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 
 before_install:
         - go get github.com/mitchellh/gox
-        - go get github.com/golang/lint/golint
+        - go get golang.org/x/lint/golint
 
 install:
         - # skip


### PR DESCRIPTION
This updates the golint import path in our CI tests.