### PR TITLE
Add Go 1.12 to the CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
                 - go: 1.9.x
                 - go: 1.10.x
                 - go: 1.11.x
+                - go: 1.12.x
                 - go: tip
         allow_failures:
                 - go: tip


### PR DESCRIPTION
This adds Go 1.12 to the CI tests

fixes #32 