### PR TITLE
Add external IP to status method

### DIFF
--- a/cmd/check_fritz/check_connection.go
+++ b/cmd/check_fritz/check_connection.go
@@ -28,7 +28,8 @@ func CheckConnectionStatus(aI ArgumentInformation) {
 	}
 
 	if resp.NewConnectionStatus == "Connected" {
-		fmt.Print("OK - Connection Status: " + resp.NewConnectionStatus + "\n")
+
+		fmt.Print("OK - Connection Status: " + resp.NewConnectionStatus + "; External IP: " + resp.NewExternalIPAddress + "\n")
 
 		GlobalReturnCode = exitOk
 	} else {


### PR DESCRIPTION
This adds the external IP to the output of the status method. The
external IP will only be shown when the check returns OK.