### PR TITLE
Implement support for Fritz!Box cable models

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Ensure that you also set the executable bit with `chmod +x check_fritz`.
 | `-i`              | `--index`        | **DEPRECATED.** **Optional.** Defines a index value required by some check methods. Defaults to none. _Marked for removal in v1.2.0._ |
 | `-a`              | `--ain`          | **Optional.** Defines the AIN required by smart device check methods. Defaults to none.                                               |
 | `-t`              | `--timeout`      | **Optional.** Defines the timeout in seconds to wait for an answer from the Fritz!Box. Defaults to `90`.                              |
+| `-M`              | `--modelgroup`   | **Optional.** Defines the Fritz!Box model group. Supported model groups are `DSL` and `Cable`. Defaults to `DSL`.                     |
 
 > **Note:**
 >
@@ -113,7 +114,8 @@ object CheckCommand "fritz" {
 		"--critical" = "$fritz_critical$"
 		"--index" = "$fritz_index$"
 		"--ain" = "$fritz_ain$"
-		"--timeout" = "$fritz_timeout"
+		"--timeout" = "$fritz_timeout$"
+		"--modelgroup" = "$fritz_modelgroup$" 
 	}
 
 	vars.fritz_hostname = "$address$"

--- a/cmd/check_fritz/check_connection.go
+++ b/cmd/check_fritz/check_connection.go
@@ -37,7 +37,7 @@ func CheckConnectionStatus(aI ArgumentInformation) {
 		return
 	}
 
-	soapResp := fritz.WANPPPConnectionResponse{}
+	soapResp := fritz.WANConnectionInfoResponse{}
 	err = fritz.UnmarshalSoapResponse(&soapResp, res)
 
 	if err != nil {
@@ -93,7 +93,7 @@ func CheckConnectionUptime(aI ArgumentInformation) {
 		return
 	}
 
-	soapResp := fritz.WANPPPConnectionResponse{}
+	soapResp := fritz.WANConnectionInfoResponse{}
 	err = fritz.UnmarshalSoapResponse(&soapResp, res)
 
 	if err != nil {

--- a/cmd/check_fritz/check_connection.go
+++ b/cmd/check_fritz/check_connection.go
@@ -28,7 +28,6 @@ func CheckConnectionStatus(aI ArgumentInformation) {
 		GlobalReturnCode = exitUnknown
 		return
 	}
-
 	go fritz.DoSoapRequest(&soapReq, resps, errs)
 
 	res, err := fritz.ProcessSoapResponse(resps, errs, 1, *aI.Timeout)
@@ -71,7 +70,20 @@ func CheckConnectionUptime(aI ArgumentInformation) {
 	resps := make(chan []byte)
 	errs := make(chan error)
 
-	soapReq := fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wanpppconn1", "WANPPPConnection", "GetInfo")
+	modelgroup := strings.ToLower(*aI.Modelgroup)
+
+	var soapReq fritz.SoapData
+
+	switch modelgroup {
+	case "dsl":
+		soapReq = fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wanpppconn1", "WANPPPConnection", "GetInfo")
+	case "cable":
+		soapReq = fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wanipconnection1", "WanIPConnection", "GetInfo")
+	default:
+		fmt.Printf("UNKNOWN - Fritz!Box modelgroup '%s' is unknown. Supported modelgroups are: DSL, CABLE\n", modelgroup)
+		GlobalReturnCode = exitUnknown
+		return
+	}
 	go fritz.DoSoapRequest(&soapReq, resps, errs)
 
 	res, err := fritz.ProcessSoapResponse(resps, errs, 1, *aI.Timeout)

--- a/cmd/check_fritz/check_connection.go
+++ b/cmd/check_fritz/check_connection.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/mcktr/check_fritz/modules/fritz"
 	"github.com/mcktr/check_fritz/modules/perfdata"
@@ -13,7 +14,21 @@ func CheckConnectionStatus(aI ArgumentInformation) {
 	resps := make(chan []byte)
 	errs := make(chan error)
 
-	soapReq := fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wanpppconn1", "WANPPPConnection", "GetInfo")
+	modelgroup := strings.ToLower(*aI.Modelgroup)
+
+	var soapReq fritz.SoapData
+
+	switch modelgroup {
+	case "dsl":
+		soapReq = fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wanpppconn1", "WANPPPConnection", "GetInfo")
+	case "cable":
+		soapReq = fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wanipconnection1", "WanIPConnection", "GetInfo")
+	default:
+		fmt.Printf("UNKNOWN - Fritz!Box modelgroup '%s' is unknown. Supported modelgroups are: DSL, CABLE\n", modelgroup)
+		GlobalReturnCode = exitUnknown
+		return
+	}
+
 	go fritz.DoSoapRequest(&soapReq, resps, errs)
 
 	res, err := fritz.ProcessSoapResponse(resps, errs, 1, *aI.Timeout)

--- a/cmd/check_fritz/main.go
+++ b/cmd/check_fritz/main.go
@@ -32,9 +32,10 @@ type ArgumentInformation struct {
 	Index         *string
 	InputVariable *string
 	Timeout       *int
+	Modelgroup    *string
 }
 
-func createRequiredArgumentInformation(hostname string, port string, username string, password string, method string, timeout string) ArgumentInformation {
+func createRequiredArgumentInformation(hostname string, port string, username string, password string, method string, timeout string, modelgroup string) ArgumentInformation {
 	var ai ArgumentInformation
 
 	ai.Hostname = &hostname
@@ -42,6 +43,7 @@ func createRequiredArgumentInformation(hostname string, port string, username st
 	ai.Username = &username
 	ai.Password = &password
 	ai.Method = &method
+	ai.Modelgroup = &modelgroup
 
 	ai.createTimeout(timeout)
 
@@ -135,6 +137,7 @@ func main() {
 	cmdline.AddOption("i", "index", "value", "DEPRECATED: Specifies the index.")
 	cmdline.AddOption("a", "ain", "value", "Specifies the AIN for smart devices.")
 	cmdline.AddOption("t", "timeout", "value", "Specifies the timeout for the request.")
+	cmdline.AddOption("M", "modelgroup", "value", "Specifies the Fritz!Box model group (DSL or Cable).")
 
 	cmdline.AddFlag("V", "version", "Returns the version")
 
@@ -143,6 +146,7 @@ func main() {
 	cmdline.SetOptionDefault("username", "dslf-config")
 	cmdline.SetOptionDefault("method", "connection_status")
 	cmdline.SetOptionDefault("timeout", "90")
+	cmdline.SetOptionDefault("modelgroup", "DSL")
 
 	cmdline.Parse(os.Args)
 
@@ -156,8 +160,9 @@ func main() {
 		password := cmdline.OptionValue("password")
 		method := cmdline.OptionValue("method")
 		timeout := cmdline.OptionValue("timeout")
+		modelgroup := cmdline.OptionValue("modelgroup")
 
-		aI := createRequiredArgumentInformation(hostname, port, username, password, method, timeout)
+		aI := createRequiredArgumentInformation(hostname, port, username, password, method, timeout, modelgroup)
 
 		if cmdline.IsOptionSet("warning") {
 			aI.createWarningThreshold(cmdline.OptionValue("warning"))

--- a/modules/fritz/fritz_response.go
+++ b/modules/fritz/fritz_response.go
@@ -10,8 +10,8 @@ import (
 type TR064Response interface {
 }
 
-// WANPPPConnectionResponse is the data structure for responses from WANPPPConnection
-type WANPPPConnectionResponse struct {
+// WANConnectionInfoResponse is the data structure for responses from WANPPPConnection
+type WANConnectionInfoResponse struct {
 	TR064Response
 	NewEnable                  string `xml:"Body>GetInfoResponse>NewEnable"`
 	NewConnectionStatus        string `xml:"Body>GetInfoResponse>NewConnectionStatus"`


### PR DESCRIPTION
This implements support for Fritz!Box cable models in the following functions: `connection_status`, `connection_uptime`.

refs #40 