### PR TITLE
Fix dividing by zero

### DIFF
--- a/cmd/check_fritz/check_downstream.go
+++ b/cmd/check_fritz/check_downstream.go
@@ -168,6 +168,12 @@ func CheckDownstreamUsage(aI ArgumentInformation) {
 
 	downstreamCurrent = downstreamCurrent * 8 / 1000000
 	downstreamMax = downstreamMax * 8 / 1000000
+
+	if downstreamMax == 0 {
+		fmt.Printf("UNKNOWN - Maximum Downstream is 0\n")
+		return
+	}
+
 	downstreamUsage := 100 / downstreamMax * downstreamCurrent
 	perfData := perfdata.CreatePerformanceData("downstream_usage", downstreamUsage, "")
 

--- a/cmd/check_fritz/check_upstream.go
+++ b/cmd/check_fritz/check_upstream.go
@@ -168,6 +168,12 @@ func CheckUpstreamUsage(aI ArgumentInformation) {
 
 	upstreamCurrent = upstreamCurrent * 8 / 1000000
 	upstreamMax = upstreamMax * 8 / 1000000
+
+	if upstreamMax == 0 {
+		fmt.Printf("UNKNOWN - Maximum Downstream is 0\n")
+		return
+	}
+
 	upstreamUsage := 100 / upstreamMax * upstreamCurrent
 	perfData := perfdata.CreatePerformanceData("upstream_usage", upstreamUsage, "")
 


### PR DESCRIPTION
Under some circumstances, e.g. when the Fritz!Box is not properly
connected with the internet the downstream_/upstream_usage checks fail
with NaN.