### PR TITLE
Query all sync groups on downstream_max/upstream_max

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,20 @@ Ensure that you also set the executable bit with `chmod +x check_fritz`.
 
 ### Parameter
 
-| Parameter (short) | Parameter (long) | Description                                                                                                                           |
-|-------------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| `-H`              | `--hostname`     | **Optional.** IP-Address or Hostname of the Fritz!Box. Defaults to `fritz.box`.                                                       |
-| `-P`              | `--port`         | **Optional.** Port for TR-064 over SSL. Defaults to `49443`.                                                                          |
-| `-u`              | `--username`     | **Optional.** Fritz!Box web interface Username for authentication. Defaults to `dslf-config`.                                         |
-| `-p`              | `--password`     | **Required.** Fritz!Box web interface Password for authentication.                                                                    |
-| `-m`              | `--method`       | **Optional.** Defines the used check method. Defaults to `connection_status`.                                                         |
-| `-w`              | `--warning`      | **Optional.** Defines a warning threshold. Defaults to none.                                                                          |
-| `-c`              | `--critical`     | **Optional.** Defines a critical threshold. Defaults to none.                                                                         |
-| `-a`              | `--ain`          | **Optional.** Defines the AIN required by smart device check methods. Defaults to none.                                               |
-| `-t`              | `--timeout`      | **Optional.** Defines the timeout in seconds to wait for an answer from the Fritz!Box. Defaults to `90`.                              |
-| `-M`              | `--modelgroup`   | **Optional.** Defines the Fritz!Box model group. Supported model groups are `DSL` and `Cable`. Defaults to `DSL`.                     |
+| Parameter (short) | Parameter (long)     | Description                                                                                                       |
+| ----------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `-H`              | `--hostname`         | **Optional.** IP-Address or Hostname of the Fritz!Box. Defaults to `fritz.box`.                                   |
+| `-P`              | `--port`             | **Optional.** Port for TR-064 over SSL. Defaults to `49443`.                                                      |
+| `-u`              | `--username`         | **Optional.** Fritz!Box web interface Username for authentication. Defaults to `dslf-config`.                     |
+| `-p`              | `--password`         | **Required.** Fritz!Box web interface Password for authentication.                                                |
+| `-m`              | `--method`           | **Optional.** Defines the used check method. Defaults to `connection_status`.                                     |
+| `-w`              | `--warning`          | **Optional.** Defines a warning threshold. Defaults to none.                                                      |
+| `-c`              | `--critical`         | **Optional.** Defines a critical threshold. Defaults to none.                                                     |
+| `-a`              | `--ain`              | **Optional.** Defines the AIN required by smart device check methods. Defaults to none.                           |
+| `-t`              | `--timeout`          | **Optional.** Defines the timeout in seconds to wait for an answer from the Fritz!Box. Defaults to `90`.          |
+| `-M`              | `--modelgroup`       | **Optional.** Defines the Fritz!Box model group. Supported model groups are `DSL` and `Cable`. Defaults to `DSL`. |
+|                   | `--ignoresyncgroups` | **Optional.** Set a ignore list for SyncGroups (separate multiple values by comma (,).                            |
+| `-d`              | `--debug`            | **Optional.** Enable debug output.                                                                                |
 
 > **Note:**
 >
@@ -78,7 +80,7 @@ Ensure that you also set the executable bit with `chmod +x check_fritz`.
 ### Methods
 
 | Name                     | Description                                                                 |
-|--------------------------|-----------------------------------------------------------------------------|
+| ------------------------ | --------------------------------------------------------------------------- |
 | `connection_status`      | WAN connection status.                                                      |
 | `connection_uptime`      | WAN connection uptime in seconds.                                           |
 | `device_uptime`          | Device uptime in seconds.                                                   |

--- a/cmd/check_fritz/check_downstream.go
+++ b/cmd/check_fritz/check_downstream.go
@@ -76,6 +76,20 @@ func CheckDownstreamMax(aI ArgumentInformation) {
 	GlobalReturnCode = exitOk
 
 	for _, r := range soapResponses {
+		if totalNumberSyncGroups > 1 {
+			if isInIgnoreList(aI.SyncGroupIgnoreList, r.NewSyncGroupName) {
+				if aI.Debug {
+					fmt.Printf("Ignoring sync group '%s' since it is in the ignore list\n", r.NewSyncGroupName)
+				}
+
+				continue
+			}
+		} else {
+			if aI.Debug {
+				fmt.Printf("The total number of sync groups is > 1, there is noting to ignore\n")
+			}
+		}
+
 		downstream, err := strconv.ParseFloat(r.NewMaxDS, 64)
 		if err != nil {
 			fmt.Printf("UNKNOWN - %s\n", err)

--- a/cmd/check_fritz/check_downstream.go
+++ b/cmd/check_fritz/check_downstream.go
@@ -12,51 +12,124 @@ import (
 
 // CheckDownstreamMax checks the maximum downstream that is available on this internet connection
 func CheckDownstreamMax(aI ArgumentInformation) {
-	resps := make(chan []byte)
-	errs := make(chan error)
+	// First query to collect total number of sync groups
+	initialResponses := make(chan []byte)
+	initialErrors := make(chan error)
 
-	soapReq := fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wancommonifconfig1", "WANCommonInterfaceConfig", "X_AVM-DE_GetOnlineMonitor")
-	soapReq.AddSoapDataVariable(fritz.CreateNewSoapVariable("NewSyncGroupIndex", "0"))
-	go fritz.DoSoapRequest(&soapReq, resps, errs, aI.Debug)
+	initialSoapRequest := fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wancommonifconfig1", "WANCommonInterfaceConfig", "X_AVM-DE_GetOnlineMonitor")
+	initialSoapRequest.AddSoapDataVariable(fritz.CreateNewSoapVariable("NewSyncGroupIndex", "0"))
+	go fritz.DoSoapRequest(&initialSoapRequest, initialResponses, initialErrors, aI.Debug)
 
-	res, err := fritz.ProcessSoapResponse(resps, errs, 1, *aI.Timeout)
-
+	initialResponse, err := fritz.ProcessSoapResponse(initialResponses, initialErrors, 1, *aI.Timeout)
 	if err != nil {
 		fmt.Printf("UNKNOWN - %s\n", err)
 		return
 	}
 
-	soapResp := fritz.WANCommonInterfaceOnlineMonitorResponse{}
-	err = fritz.UnmarshalSoapResponse(&soapResp, res)
-
-	downstream, err := strconv.ParseFloat(soapResp.NewMaxDS, 64)
-
+	initialSoapResponse := fritz.WANCommonInterfaceOnlineMonitorResponse{}
+	err = fritz.UnmarshalSoapResponse(&initialSoapResponse, initialResponse)
 	if err != nil {
-		panic(err)
+		fmt.Printf("UNKNOWN - %s\n", err)
+		return
 	}
 
-	downstream = downstream * 8 / 1000000
-	perfData := perfdata.CreatePerformanceData("downstream_max", downstream, "")
+	soapResponses := []fritz.WANCommonInterfaceOnlineMonitorResponse{}
+	soapResponses = append(soapResponses, initialSoapResponse)
 
+	totalNumberSyncGroups, err := strconv.Atoi(initialSoapResponse.NewTotalNumberSyncGroups)
+	if err != nil {
+		fmt.Printf("UNKNOWN - %s\n", err)
+		return
+	}
+
+	// If there are more sync groups query all other sync groups, starting with the next one
+	if totalNumberSyncGroups > 1 {
+		for i := 1; i < totalNumberSyncGroups; i++ {
+			responses := make(chan []byte)
+			errors := make(chan error)
+
+			soapRequest := initialSoapRequest
+			soapRequest.AddSoapDataVariable(fritz.CreateNewSoapVariable("NewSyncGroupIndex", strconv.Itoa(i)))
+
+			go fritz.DoSoapRequest(&soapRequest, responses, errors, aI.Debug)
+
+			response, err := fritz.ProcessSoapResponse(responses, errors, 1, *aI.Timeout)
+			if err != nil {
+				fmt.Printf("UNKNOWN - %s\n", err)
+				return
+			}
+
+			soapResponse := fritz.WANCommonInterfaceOnlineMonitorResponse{}
+			err = fritz.UnmarshalSoapResponse(&soapResponse, response)
+			if err != nil {
+				fmt.Printf("UNKNOWN - %s\n", err)
+				return
+			}
+
+			soapResponses = append(soapResponses, soapResponse)
+		}
+	}
+
+	downstreamCombined := 0.0
+	output := ""
+	performanceData := []perfdata.PerformanceData{}
 	GlobalReturnCode = exitOk
 
-	if thresholds.IsSet(aI.Warning) {
-		perfData.SetWarning(*aI.Warning)
+	for _, r := range soapResponses {
+		downstream, err := strconv.ParseFloat(r.NewMaxDS, 64)
+		if err != nil {
+			fmt.Printf("UNKNOWN - %s\n", err)
+			return
+		}
 
-		if thresholds.CheckLower(*aI.Warning, downstream) {
+		downstreamCombined += downstream
+		downstream = downstream * 8 / 1000000
+
+		output += fmt.Sprintf(", Downstream SyncGroup '%s': %.2f Mbit/s", r.NewSyncGroupName, downstream)
+
+		pd := perfdata.CreatePerformanceData("downstream_max_"+fmt.Sprintf("%s", r.NewSyncGroupName), downstream, "")
+
+		if thresholds.IsSet(aI.Warning) {
+			pd.SetWarning(*aI.Warning)
+
+			if thresholds.CheckLower(*aI.Warning, downstream) {
+				GlobalReturnCode = exitWarning
+			}
+		}
+
+		if thresholds.IsSet(aI.Critical) {
+			pd.SetCritical(*aI.Critical)
+
+			if thresholds.CheckLower(*aI.Critical, downstream) {
+				GlobalReturnCode = exitCritical
+			}
+		}
+
+		performanceData = append(performanceData, *pd)
+	}
+
+	downstreamCombined = downstreamCombined * 8 / 1000000
+	pdDownstreamCombined := perfdata.CreatePerformanceData("downstream_max", downstreamCombined, "")
+
+	if thresholds.IsSet(aI.Warning) {
+		pdDownstreamCombined.SetWarning(*aI.Warning)
+
+		if thresholds.CheckLower(*aI.Warning, downstreamCombined) {
 			GlobalReturnCode = exitWarning
 		}
 	}
 
 	if thresholds.IsSet(aI.Critical) {
-		perfData.SetCritical(*aI.Critical)
+		pdDownstreamCombined.SetCritical(*aI.Critical)
 
-		if thresholds.CheckLower(*aI.Critical, downstream) {
+		if thresholds.CheckLower(*aI.Critical, downstreamCombined) {
 			GlobalReturnCode = exitCritical
 		}
 	}
 
-	output := " - Max Downstream: " + fmt.Sprintf("%.2f", downstream) + " Mbit/s " + perfData.GetPerformanceDataAsString()
+	performanceData = append(performanceData, *pdDownstreamCombined)
+
+	output = " - Max Downstream: " + fmt.Sprintf("%.2f", downstreamCombined) + " Mbit/s" + output + perfdata.FormatAsString(performanceData)
 
 	switch GlobalReturnCode {
 	case exitOk:

--- a/cmd/check_fritz/check_upstream.go
+++ b/cmd/check_fritz/check_upstream.go
@@ -12,51 +12,124 @@ import (
 
 // CheckUpstreamMax checks the maximum upstream that is available on this internet connection
 func CheckUpstreamMax(aI ArgumentInformation) {
-	resps := make(chan []byte)
-	errs := make(chan error)
+	// First query to collect total number of sync groups
+	initialResponses := make(chan []byte)
+	initialErrors := make(chan error)
 
-	soapReq := fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wancommonifconfig1", "WANCommonInterfaceConfig", "X_AVM-DE_GetOnlineMonitor")
-	soapReq.AddSoapDataVariable(fritz.CreateNewSoapVariable("NewSyncGroupIndex", "0"))
-	go fritz.DoSoapRequest(&soapReq, resps, errs, aI.Debug)
+	initialSoapRequest := fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wancommonifconfig1", "WANCommonInterfaceConfig", "X_AVM-DE_GetOnlineMonitor")
+	initialSoapRequest.AddSoapDataVariable(fritz.CreateNewSoapVariable("NewSyncGroupIndex", "0"))
+	go fritz.DoSoapRequest(&initialSoapRequest, initialResponses, initialErrors, aI.Debug)
 
-	res, err := fritz.ProcessSoapResponse(resps, errs, 1, *aI.Timeout)
-
+	initialResponse, err := fritz.ProcessSoapResponse(initialResponses, initialErrors, 1, *aI.Timeout)
 	if err != nil {
 		fmt.Printf("UNKNOWN - %s\n", err)
 		return
 	}
 
-	soapResp := fritz.WANCommonInterfaceOnlineMonitorResponse{}
-	err = fritz.UnmarshalSoapResponse(&soapResp, res)
-
-	upstream, err := strconv.ParseFloat(soapResp.NewMaxUS, 64)
-
+	initialSoapResponse := fritz.WANCommonInterfaceOnlineMonitorResponse{}
+	err = fritz.UnmarshalSoapResponse(&initialSoapResponse, initialResponse)
 	if err != nil {
-		panic(err)
+		fmt.Printf("UNKNOWN - %s\n", err)
+		return
 	}
 
-	upstream = upstream * 8 / 1000000
-	perfData := perfdata.CreatePerformanceData("upstream_max", upstream, "")
+	soapResponses := []fritz.WANCommonInterfaceOnlineMonitorResponse{}
+	soapResponses = append(soapResponses, initialSoapResponse)
 
+	totalNumberSyncGroups, err := strconv.Atoi(initialSoapResponse.NewTotalNumberSyncGroups)
+	if err != nil {
+		fmt.Printf("UNKNOWN - %s\n", err)
+		return
+	}
+
+	// If there are more sync groups query all other sync groups, starting with the next one
+	if totalNumberSyncGroups > 1 {
+		for i := 1; i < totalNumberSyncGroups; i++ {
+			responses := make(chan []byte)
+			errors := make(chan error)
+
+			soapRequest := initialSoapRequest
+			soapRequest.AddSoapDataVariable(fritz.CreateNewSoapVariable("NewSyncGroupIndex", strconv.Itoa(i)))
+
+			go fritz.DoSoapRequest(&soapRequest, responses, errors, aI.Debug)
+
+			response, err := fritz.ProcessSoapResponse(responses, errors, 1, *aI.Timeout)
+			if err != nil {
+				fmt.Printf("UNKNOWN - %s\n", err)
+				return
+			}
+
+			soapResponse := fritz.WANCommonInterfaceOnlineMonitorResponse{}
+			err = fritz.UnmarshalSoapResponse(&soapResponse, response)
+			if err != nil {
+				fmt.Printf("UNKNOWN - %s\n", err)
+				return
+			}
+
+			soapResponses = append(soapResponses, soapResponse)
+		}
+	}
+
+	upstreamCombined := 0.0
+	output := ""
+	performanceData := []perfdata.PerformanceData{}
 	GlobalReturnCode = exitOk
 
-	if thresholds.IsSet(aI.Warning) {
-		perfData.SetWarning(*aI.Warning)
+	for _, r := range soapResponses {
+		upstream, err := strconv.ParseFloat(r.NewMaxUS, 64)
+		if err != nil {
+			fmt.Printf("UNKNOWN - %s\n", err)
+			return
+		}
 
-		if thresholds.CheckLower(*aI.Warning, upstream) {
+		upstreamCombined += upstream
+		upstream = upstream * 8 / 1000000
+
+		output += fmt.Sprintf(", Upstream SyncGroup '%s': %.2f Mbit/s", r.NewSyncGroupName, upstream)
+
+		pd := perfdata.CreatePerformanceData("upstream_max_"+fmt.Sprintf("%s", r.NewSyncGroupName), upstream, "")
+
+		if thresholds.IsSet(aI.Warning) {
+			pd.SetWarning(*aI.Warning)
+
+			if thresholds.CheckLower(*aI.Warning, upstream) {
+				GlobalReturnCode = exitWarning
+			}
+		}
+
+		if thresholds.IsSet(aI.Critical) {
+			pd.SetCritical(*aI.Critical)
+
+			if thresholds.CheckLower(*aI.Critical, upstream) {
+				GlobalReturnCode = exitCritical
+			}
+		}
+
+		performanceData = append(performanceData, *pd)
+	}
+
+	upstreamCombined = upstreamCombined * 8 / 1000000
+	pdUpstreamCombined := perfdata.CreatePerformanceData("upstream_max", upstreamCombined, "")
+
+	if thresholds.IsSet(aI.Warning) {
+		pdUpstreamCombined.SetWarning(*aI.Warning)
+
+		if thresholds.CheckLower(*aI.Warning, upstreamCombined) {
 			GlobalReturnCode = exitWarning
 		}
 	}
 
 	if thresholds.IsSet(aI.Critical) {
-		perfData.SetCritical(*aI.Critical)
+		pdUpstreamCombined.SetCritical(*aI.Critical)
 
-		if thresholds.CheckLower(*aI.Critical, upstream) {
+		if thresholds.CheckLower(*aI.Critical, upstreamCombined) {
 			GlobalReturnCode = exitCritical
 		}
 	}
 
-	output := " - Max Upstream: " + fmt.Sprintf("%.2f", upstream) + " Mbit/s " + perfData.GetPerformanceDataAsString()
+	performanceData = append(performanceData, *pdUpstreamCombined)
+
+	output = " - Max Upstream: " + fmt.Sprintf("%.2f", upstreamCombined) + " Mbit/s" + output + perfdata.FormatAsString(performanceData)
 
 	switch GlobalReturnCode {
 	case exitOk:

--- a/cmd/check_fritz/check_upstream.go
+++ b/cmd/check_fritz/check_upstream.go
@@ -76,6 +76,20 @@ func CheckUpstreamMax(aI ArgumentInformation) {
 	GlobalReturnCode = exitOk
 
 	for _, r := range soapResponses {
+		if totalNumberSyncGroups > 1 {
+			if isInIgnoreList(aI.SyncGroupIgnoreList, r.NewSyncGroupName) {
+				if aI.Debug {
+					fmt.Printf("Ignoring sync group '%s' since it is in the ignore list\n", r.NewSyncGroupName)
+				}
+
+				continue
+			}
+		} else {
+			if aI.Debug {
+				fmt.Printf("The total number of sync groups is > 1, there is noting to ignore\n")
+			}
+		}
+
 		upstream, err := strconv.ParseFloat(r.NewMaxUS, 64)
 		if err != nil {
 			fmt.Printf("UNKNOWN - %s\n", err)

--- a/cmd/check_fritz/main.go
+++ b/cmd/check_fritz/main.go
@@ -83,6 +83,10 @@ func (ai *ArgumentInformation) setSyncGroupIgnoreList(l string) {
 }
 
 func isInIgnoreList(list *[]string, value string) bool {
+	if list == nil {
+		return false
+	}
+
 	for _, v := range *list {
 		if strings.ToLower(value) == strings.ToLower(v) {
 			return true

--- a/cmd/check_fritz/main.go
+++ b/cmd/check_fritz/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 )
@@ -23,17 +24,18 @@ var GlobalReturnCode = exitUnknown
 
 // ArgumentInformation is the data structure for the passed arguments
 type ArgumentInformation struct {
-	Hostname      *string
-	Port          *string
-	Username      *string
-	Password      *string
-	Method        *string
-	Warning       *float64
-	Critical      *float64
-	InputVariable *string
-	Timeout       *int
-	Modelgroup    *string
-	Debug         bool
+	Hostname            *string
+	Port                *string
+	Username            *string
+	Password            *string
+	Method              *string
+	Warning             *float64
+	Critical            *float64
+	InputVariable       *string
+	Timeout             *int
+	Modelgroup          *string
+	Debug               bool
+	SyncGroupIgnoreList *[]string
 }
 
 func createRequiredArgumentInformation(hostname string, port string, username string, password string, method string, timeout int, modelgroup string) ArgumentInformation {
@@ -65,6 +67,29 @@ func (ai *ArgumentInformation) createInputVariable(v string) {
 
 func (ai *ArgumentInformation) setDebugMode() {
 	ai.Debug = true
+}
+
+func (ai *ArgumentInformation) setSyncGroupIgnoreList(l string) {
+	var ignoreList []string
+
+	if strings.Contains(l, ",") {
+		ignoreList = strings.Split(l, ",")
+
+	} else {
+		ignoreList = append(ignoreList, l)
+	}
+
+	ai.SyncGroupIgnoreList = &ignoreList
+}
+
+func isInIgnoreList(list *[]string, value string) bool {
+	for _, v := range *list {
+		if strings.ToLower(value) == strings.ToLower(v) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func printVersion() {
@@ -144,6 +169,10 @@ func checkMain(c *cli.Context) error {
 
 	if c.IsSet("debug") {
 		argInfo.setDebugMode()
+	}
+
+	if c.IsSet("ignoresyncgroups") {
+		argInfo.setSyncGroupIgnoreList(c.String("ignoresyncgroups"))
 	}
 
 	if !checkRequiredFlags(&argInfo) {
@@ -261,6 +290,10 @@ func main() {
 				Name:    "debug",
 				Aliases: []string{"d"},
 				Usage:   "Outputs debug information",
+			},
+			&cli.StringFlag{
+				Name:  "ignoresyncgroups",
+				Usage: "Set a ignore list for SyncGroups (separate multiple values by comma (,))",
 			},
 		},
 	}

--- a/modules/perfdata/perfdata.go
+++ b/modules/perfdata/perfdata.go
@@ -50,3 +50,13 @@ func (pd *PerformanceData) SetMaximum(Maximum float64) {
 func (pd *PerformanceData) GetPerformanceDataAsString() string {
 	return fmt.Sprintf("| '%s'=%f%s;%s;%s;%s;%s", pd.Label, pd.Value, pd.UOM, pd.Warning, pd.Critical, pd.Minimum, pd.Maximum)
 }
+
+func FormatAsString(pds []PerformanceData) string {
+	output := " |"
+
+	for _, pd := range pds {
+		output += fmt.Sprintf(" '%s'=%f%s;%s;%s;%s;%s", pd.Label, pd.Value, pd.UOM, pd.Warning, pd.Critical, pd.Minimum, pd.Maximum)
+	}
+
+	return output
+}


### PR DESCRIPTION
Changes the downstream_max and upstream_max method to query all found
sync groups to ensure a correct calculated max down-/up-stream value.

**ToDo**

- [x] Implement a ignore list for sync groups, see https://github.com/mcktr/check_fritz/pull/83#issuecomment-651294392

fixes #72