### PR TITLE
Enhance the build process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,30 +1,34 @@
 name: CI
-on: [push, pull_request]
+on:
+  pull_request: {}
+
 jobs:
-        build:
-                name: Build
-                strategy:
-                        matrix:
-                                go-version: [1.12.x, 1.13.x, 1.14.x]
-                                platform: [ubuntu-latest, macos-latest, windows-latest]
-                runs-on: ${{ matrix.platform }}
-                steps:
-                        - name: Install Go
-                          uses: actions/setup-go@v1
-                          with:
-                                  go-version: ${{ matrix.go-version }}
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.13, 1.14, 1.15]
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
 
-                        - name: Checkout Code
-                          uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-                        - name: Resolve Dependencies
-                          run: go get -v -t -d ./...
+      - name: Resolve Dependencies
+        run: go get -v -t -d ./...
 
-                        - name: Build Application
-                          run: go build -v -o check_fritz ./cmd/check_fritz
+      - name: Go Test
+        run: make test
 
-                        - name: Upload Artifact
-                          uses: actions/upload-artifact@v2
-                          with:
-                                  name: check_fritz.${{ matrix.platform }}_${{ matrix.go-version }}
-                                  path: check_fritz
+      - name: Go Build
+        run: make build
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: check_fritz_${{ matrix.go-version }}
+          path: build/check_fritz*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Build Release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.15
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Resolve Dependencies
+        run: go get -v -t -d ./...
+
+      - name: Go Test
+        run: make test
+
+      - name: Go Build
+        run: make build
+
+      - name: Create Release Draft
+        run: |
+          set -x
+          assets=()
+          for asset in ./build/*; do
+            assets+=("--attach" "$asset")
+          done
+          tag_name="${GITHUB_REF##*/}"
+          hub release create "${assets[@]}" --draft -m "$tag_name" "$tag_name"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,27 @@
-.PHONY : all
-all : build.linux build.windows build.darwin
+VERSION := $(shell git describe --tags)
+BUILD := go build -v -ldflags "-s -w -X main.Version=$(VERSION)"
 
-build.linux: build.linux.amd64 build.linux.arm64 build.linux.arm5 build.linux.arm6 build.linux.arm7
-build.windows: build.windows.amd64
-build.darwin: build.darwin.amd64
+BINARY = check_fritz
 
-build.linux.amd64:
-	GOOS=linux GOARCH=amd64 go build -a -v -o "check_fritz.linux.amd64" ./cmd/check_fritz/
-	sha256sum check_fritz.linux.amd64 > check_fritz.linux.amd64.sha256
+.PHONY : all clean build test
 
-build.linux.arm64:
-	GOOS=linux GOARCH=arm64 go build -a -v -o "check_fritz.linux.arm64" ./cmd/check_fritz/
-	sha256sum check_fritz.linux.arm64 > check_fritz.linux.arm64.sha256
+all: build test
 
-build.linux.arm5:
-	GOOS=linux GOARCH=arm GOARM=5 go build -a -v -o "check_fritz.linux.arm5" ./cmd/check_fritz/
-	sha256sum check_fritz.linux.arm5 > check_fritz.linux.arm5.sha256
+test:
+	go test -v ./...
 
-build.linux.arm6:
-	GOOS=linux GOARCH=arm GOARM=6 go build -a -v -o "check_fritz.linux.arm6" ./cmd/check_fritz/
-	sha256sum check_fritz.linux.arm6 > check_fritz.linux.arm6.sha256
+clean:
+	rm -rf build/
 
-build.linux.arm7:
-	GOOS=linux GOARCH=arm GOARM=7 go build -a -v -o "check_fritz.linux.arm7" ./cmd/check_fritz/
-	sha256sum check_fritz.linux.arm7 > check_fritz.linux.arm7.sha256
-
-build.windows.amd64:
-	GOOS=windows GOARCH=amd64 go build -a -v -o "check_fritz.windows.amd64.exe" ./cmd/check_fritz/
-	sha256sum check_fritz.windows.amd64.exe > check_fritz.windows.amd64.exe.sha256
-
-build.darwin.amd64:
-	GOOS=darwin GOARCH=amd64 go build -a -v -o "check_fritz.darwin.amd64" ./cmd/check_fritz/
-	sha256sum check_fritz.darwin.amd64 > check_fritz.darwin.amd64.sha256
+build:
+	mkdir -p build
+	GOOS=linux GOARCH=amd64 $(BUILD) -o build/$(BINARY).linux.amd64 ./cmd/check_fritz
+	sha256sum build/$(BINARY).linux.amd64 > build/$(BINARY).linux.amd64.sha256
+	GOOS=linux GOARCH=arm64 $(BUILD) -o build/$(BINARY).linux.arm64 ./cmd/check_fritz
+	sha256sum build/$(BINARY).linux.arm64 > build/$(BINARY).linux.arm64.sha256
+	GOOS=linux GOARCH=arm $(BUILD) -o build/$(BINARY).linux.arm ./cmd/check_fritz
+	sha256sum build/$(BINARY).linux.arm > build/$(BINARY).linux.arm.sha256
+	GOOS=windows GOARCH=amd64 $(BUILD) -o build/$(BINARY).windows.amd64.exe ./cmd/check_fritz
+	sha256sum build/$(BINARY).windows.amd64.exe > build/$(BINARY).windows.amd64.exe.sha256
+	GOOS=darwin GOARCH=amd64 $(BUILD) -o build/$(BINARY).darwin.amd64 ./cmd/check_fritz
+	sha256sum build/$(BINARY).darwin.amd64 > build/$(BINARY).darwin.amd64.sha256

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell git describe --tags)
+VERSION := $(shell git describe --tags --always)
 BUILD := go build -v -ldflags "-s -w -X main.Version=$(VERSION)"
 
 BINARY = check_fritz

--- a/cmd/check_fritz/main.go
+++ b/cmd/check_fritz/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 // program version
-const version = "1.1.0"
+var Version = "1.1.0"
 
 // internal exit codes
 const (
@@ -68,7 +68,7 @@ func (ai *ArgumentInformation) setDebugMode() {
 }
 
 func printVersion() {
-	fmt.Println("check_fritz v" + version)
+	fmt.Println("check_fritz v" + Version)
 	GlobalReturnCode = exitOk
 }
 
@@ -194,7 +194,7 @@ func main() {
 		Action:  checkMain,
 		Name:    "check_fritz",
 		Usage:   "Check plugin to monitor a Fritz!Box",
-		Version: version,
+		Version: Version,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "hostname",


### PR DESCRIPTION
The version will now be set during the build process `(-ldflags "-X")`.
The build process will now also strip the symbol table, debug
information and the DWARF table from the binary `(-ldflags "-s -w")`.

The GitHub workflow CI now builds only on the 3 latest Go version,
currently 1.13, 1.14 and 1.15. A new workflow is introduced to build the
release binaries and create a release draft. The release workflow will
use the latest Go version, currently 1.15.

fixes #74