### PR TITLE
Fix nil pointer dereference in smart check methods

### DIFF
--- a/cmd/check_fritz/check_smart.go
+++ b/cmd/check_fritz/check_smart.go
@@ -15,6 +15,12 @@ func CheckSpecificSmartStatus(aI ArgumentInformation) {
 	errs := make(chan error)
 
 	soapReq := fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/x_homeauto", "X_AVM-DE_Homeauto", "GetSpecificDeviceInfos")
+
+	if aI.InputVariable == nil {
+		fmt.Printf("UNKNOWN - a AIN needs to be set for this check method\n")
+		return
+	}
+
 	soapReq.AddSoapDataVariable(fritz.CreateNewSoapVariable("NewAIN", *aI.InputVariable))
 	go fritz.DoSoapRequest(&soapReq, resps, errs, aI.Debug)
 
@@ -58,6 +64,12 @@ func CheckSpecificSmartHeaterTemperatur(aI ArgumentInformation) {
 	errs := make(chan error)
 
 	soapReq := fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/x_homeauto", "X_AVM-DE_Homeauto", "GetSpecificDeviceInfos")
+
+	if aI.InputVariable == nil {
+		fmt.Printf("UNKNOWN - a AIN needs to be set for this check method\n")
+		return
+	}
+
 	soapReq.AddSoapDataVariable(fritz.CreateNewSoapVariable("NewAIN", *aI.InputVariable))
 	go fritz.DoSoapRequest(&soapReq, resps, errs, aI.Debug)
 
@@ -129,6 +141,12 @@ func CheckSpecificSmartSocketPower(aI ArgumentInformation) {
 	errs := make(chan error)
 
 	soapReq := fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/x_homeauto", "X_AVM-DE_Homeauto", "GetSpecificDeviceInfos")
+
+	if aI.InputVariable == nil {
+		fmt.Printf("UNKNOWN - a AIN needs to be set for this check method\n")
+		return
+	}
+
 	soapReq.AddSoapDataVariable(fritz.CreateNewSoapVariable("NewAIN", *aI.InputVariable))
 	go fritz.DoSoapRequest(&soapReq, resps, errs, aI.Debug)
 
@@ -194,6 +212,12 @@ func CheckSpecificSmartSocketEnergy(aI ArgumentInformation) {
 	errs := make(chan error)
 
 	soapReq := fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/x_homeauto", "X_AVM-DE_Homeauto", "GetSpecificDeviceInfos")
+
+	if aI.InputVariable == nil {
+		fmt.Printf("UNKNOWN - a AIN needs to be set for this check method\n")
+		return
+	}
+
 	soapReq.AddSoapDataVariable(fritz.CreateNewSoapVariable("NewAIN", *aI.InputVariable))
 	go fritz.DoSoapRequest(&soapReq, resps, errs, aI.Debug)
 


### PR DESCRIPTION
Fixes a nil pointer dereference in the smart check methods. The AIN
needs to be set for the check methods.

# before

```
$ go run cmd/check_fritz/*.go -H 192.168.178.1 -p secret -m smart_heatertemperatur
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x77aabb]

```

# after

```
$ go run cmd/check_fritz/*.go -H 192.168.178.1 -p secret -m smart_heatertemperatur
UNKNOWN - a AIN needs to be set for this check method
exit status 3

```

fixes #88