### PR TITLE
Fix wrong values for max down-/upstream

### DIFF
--- a/cmd/check_fritz/check_downstream.go
+++ b/cmd/check_fritz/check_downstream.go
@@ -196,14 +196,62 @@ func CheckDownstreamUsage(aI ArgumentInformation) {
 		panic(err)
 	}
 
-	downstreamMax, err := strconv.ParseFloat(soapResp.NewMaxDS, 64)
+	isDSL := false
+
+	if strings.ToLower(*aI.Modelgroup) == "dsl" {
+		isDSL = true
+	}
+
+	if isDSL {
+		soapReq = fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wandslifconfig1", "WANDSLInterfaceConfig", "GetInfo")
+	} else {
+		soapReq = fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wancommonifconfig1", "WANCommonInterfaceConfig", "GetCommonLinkProperties")
+	}
+
+	go fritz.DoSoapRequest(&soapReq, resps, errs, aI.Debug)
+
+	res, err = fritz.ProcessSoapResponse(resps, errs, 1, *aI.Timeout)
 
 	if err != nil {
-		panic(err)
+		fmt.Printf("UNKNOWN - %s\n", err)
+		return
+	}
+
+	var downstreamMax float64
+
+	if isDSL {
+		soapResp := fritz.WANDSLInterfaceGetInfoResponse{}
+		err = fritz.UnmarshalSoapResponse(&soapResp, res)
+
+		if err != nil {
+			panic(err)
+		}
+
+		ups, err := strconv.ParseFloat(soapResp.NewDownstreamCurrRate, 64)
+
+		if err != nil {
+			panic(err)
+		}
+
+		downstreamMax = ups / 1000
+	} else {
+		soapResp := fritz.WANCommonInterfaceCommonLinkPropertiesResponse{}
+		err = fritz.UnmarshalSoapResponse(&soapResp, res)
+
+		if err != nil {
+			panic(err)
+		}
+
+		ups, err := strconv.ParseFloat(soapResp.NewLayer1DownstreamMaxBitRate, 64)
+
+		if err != nil {
+			panic(err)
+		}
+
+		downstreamMax = ups / 1000000
 	}
 
 	downstreamCurrent = downstreamCurrent * 8 / 1000000
-	downstreamMax = downstreamMax * 8 / 1000000
 
 	if downstreamMax == 0 {
 		fmt.Printf("UNKNOWN - Maximum Downstream is 0\n")

--- a/cmd/check_fritz/check_upstream.go
+++ b/cmd/check_fritz/check_upstream.go
@@ -196,14 +196,62 @@ func CheckUpstreamUsage(aI ArgumentInformation) {
 		panic(err)
 	}
 
-	upstreamMax, err := strconv.ParseFloat(soapResp.NewMaxUS, 64)
+	isDSL := false
+
+	if strings.ToLower(*aI.Modelgroup) == "dsl" {
+		isDSL = true
+	}
+
+	if isDSL {
+		soapReq = fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wandslifconfig1", "WANDSLInterfaceConfig", "GetInfo")
+	} else {
+		soapReq = fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wancommonifconfig1", "WANCommonInterfaceConfig", "GetCommonLinkProperties")
+	}
+
+	go fritz.DoSoapRequest(&soapReq, resps, errs, aI.Debug)
+
+	res, err = fritz.ProcessSoapResponse(resps, errs, 1, *aI.Timeout)
 
 	if err != nil {
-		panic(err)
+		fmt.Printf("UNKNOWN - %s\n", err)
+		return
+	}
+
+	var upstreamMax float64
+
+	if isDSL {
+		soapResp := fritz.WANDSLInterfaceGetInfoResponse{}
+		err = fritz.UnmarshalSoapResponse(&soapResp, res)
+
+		if err != nil {
+			panic(err)
+		}
+
+		ups, err := strconv.ParseFloat(soapResp.NewUpstreamCurrRate, 64)
+
+		if err != nil {
+			panic(err)
+		}
+
+		upstreamMax = ups / 1000
+	} else {
+		soapResp := fritz.WANCommonInterfaceCommonLinkPropertiesResponse{}
+		err = fritz.UnmarshalSoapResponse(&soapResp, res)
+
+		if err != nil {
+			panic(err)
+		}
+
+		ups, err := strconv.ParseFloat(soapResp.NewLayer1UpstreamMaxBitRate, 64)
+
+		if err != nil {
+			panic(err)
+		}
+
+		upstreamMax = ups / 1000000
 	}
 
 	upstreamCurrent = upstreamCurrent * 8 / 1000000
-	upstreamMax = upstreamMax * 8 / 1000000
 
 	if upstreamMax == 0 {
 		fmt.Printf("UNKNOWN - Maximum Downstream is 0\n")

--- a/cmd/check_fritz/check_upstream.go
+++ b/cmd/check_fritz/check_upstream.go
@@ -15,8 +15,20 @@ func CheckUpstreamMax(aI ArgumentInformation) {
 	resps := make(chan []byte)
 	errs := make(chan error)
 
-	soapReq := fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wancommonifconfig1", "WANCommonInterfaceConfig", "X_AVM-DE_GetOnlineMonitor")
-	soapReq.AddSoapDataVariable(fritz.CreateNewSoapVariable("NewSyncGroupIndex", "0"))
+	var soapReq fritz.SoapData
+
+	isDSL := false
+
+	if strings.ToLower(*aI.Modelgroup) == "dsl" {
+		isDSL = true
+	}
+
+	if isDSL {
+		soapReq = fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wandslifconfig1", "WANDSLInterfaceConfig", "GetInfo")
+	} else {
+		soapReq = fritz.CreateNewSoapData(*aI.Username, *aI.Password, *aI.Hostname, *aI.Port, "/upnp/control/wancommonifconfig1", "WANCommonInterfaceConfig", "GetCommonLinkProperties")
+	}
+
 	go fritz.DoSoapRequest(&soapReq, resps, errs, aI.Debug)
 
 	res, err := fritz.ProcessSoapResponse(resps, errs, 1, *aI.Timeout)
@@ -26,16 +38,40 @@ func CheckUpstreamMax(aI ArgumentInformation) {
 		return
 	}
 
-	soapResp := fritz.WANCommonInterfaceOnlineMonitorResponse{}
-	err = fritz.UnmarshalSoapResponse(&soapResp, res)
+	var upstream float64
 
-	upstream, err := strconv.ParseFloat(soapResp.NewMaxUS, 64)
+	if isDSL {
+		soapResp := fritz.WANDSLInterfaceGetInfoResponse{}
+		err = fritz.UnmarshalSoapResponse(&soapResp, res)
 
-	if err != nil {
-		panic(err)
+		if err != nil {
+			panic(err)
+		}
+
+		ups, err := strconv.ParseFloat(soapResp.NewUpstreamCurrRate, 64)
+
+		if err != nil {
+			panic(err)
+		}
+
+		upstream = ups / 1000
+	} else {
+		soapResp := fritz.WANCommonInterfaceCommonLinkPropertiesResponse{}
+		err = fritz.UnmarshalSoapResponse(&soapResp, res)
+
+		if err != nil {
+			panic(err)
+		}
+
+		ups, err := strconv.ParseFloat(soapResp.NewLayer1UpstreamMaxBitRate, 64)
+
+		if err != nil {
+			panic(err)
+		}
+
+		upstream = ups / 1000000
 	}
 
-	upstream = upstream * 8 / 1000000
 	perfData := perfdata.CreatePerformanceData("upstream_max", upstream, "")
 
 	GlobalReturnCode = exitOk

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -7,6 +7,25 @@
 The parameter `-i` (`--index`) got removed with the release of v1.2.0. Use the successor `-a` (`--ain`) instead, please
 read the upgrading to v1.1.0 for details on how to optain the AIN from the Fritz!Box web interface.
 
+### Downstream and Upstream calculation
+
+A bug was discovered that makes it necessary to provide the `--modelgroup` (short `-M`) parameter to the following 
+functions, if you use a non DSL Fritz!Box e.g. a Fritz!Box 6591 Cable.
+
+* `downstream_max`
+* `downstream_usage`
+* `upstream_max`
+* `upstream_usage`
+
+_Example:_
+
+```
+$ ./check_fritz --password secret --method downstream_usage --modelgroup cable
+```
+
+If you are using a DSL Fritz!Box e.g. a Fritz!Box 7490 you don't need to provide the `--modelgroup` parameter because
+the default will use `DSL` as modelgroup.
+
 ## Upgrading to v1.1.0
 
 ### Index parameter

--- a/modules/fritz/fritz_response.go
+++ b/modules/fritz/fritz_response.go
@@ -163,6 +163,35 @@ type SmartSpecificDeviceInfoResponse struct {
 	NewHkrComfortTemperature  string `xml:"Body>GetSpecificDeviceInfosResponse>NewHkrComfortTemperature"`
 }
 
+// WANCommonInterfaceCommonLinkPropertiesResponse is the date structure for responses from GetCommonLinkProperties
+type WANCommonInterfaceCommonLinkPropertiesResponse struct {
+	TR064Response
+	NewWANAccessType              string `xml:"Body>GetCommonLinkPropertiesResponse>GetCommonLinkPropertiesResponse"`
+	NewLayer1UpstreamMaxBitRate   string `xml:"Body>GetCommonLinkPropertiesResponse>NewLayer1UpstreamMaxBitRate"`
+	NewLayer1DownstreamMaxBitRate string `xml:"Body>GetCommonLinkPropertiesResponse>NewLayer1DownstreamMaxBitRate"`
+	NewPhysicalLinkStatus         string `xml:"Body>GetCommonLinkPropertiesResponse>NewPhysicalLinkStatus"`
+}
+
+// WANDSLInterfaceGetInfoResponse is the date structure for responses from GetInfo
+type WANDSLInterfaceGetInfoResponse struct {
+	TR064Response
+	NewEnable                string `xml:"Body>GetInfoResponse>NewEnable"`
+	NewStatus                string `xml:"Body>GetInfoResponse>NewStatus"`
+	NewDataPath              string `xml:"Body>GetInfoResponse>NewDataPath"`
+	NewUpstreamCurrRate      string `xml:"Body>GetInfoResponse>NewUpstreamCurrRate"`
+	NewDownstreamCurrRate    string `xml:"Body>GetInfoResponse>NewDownstreamCurrRate"`
+	NewUpstreamMaxRate       string `xml:"Body>GetInfoResponse>NewUpstreamMaxRate"`
+	NewDownstreamMaxRate     string `xml:"Body>GetInfoResponse>NewDownstreamMaxRate"`
+	NewUpstreamNoiseMargin   string `xml:"Body>GetInfoResponse>NewUpstreamNoiseMargin"`
+	NewDownstreamNoiseMargin string `xml:"Body>GetInfoResponse>NewDownstreamNoiseMargin"`
+	NewUpstreamAttenuation   string `xml:"Body>GetInfoResponse>NewUpstreamAttenuation"`
+	NewDownstreamAttenuation string `xml:"Body>GetInfoResponse>NewDownstreamAttenuation"`
+	NewATURVendor            string `xml:"Body>GetInfoResponse>NewATURVendor"`
+	NewATURCountry           string `xml:"Body>GetInfoResponse>NewATURCountry"`
+	NewUpstreamPower         string `xml:"Body>GetInfoResponse>NewUpstreamPower"`
+	NewDownstreamPower       string `xml:"Body>GetInfoResponse>NewDownstreamPower"`
+}
+
 // UnmarshalSoapResponse unmarshals the soap response to the data structure
 func UnmarshalSoapResponse(resp TR064Response, inputXML [][]byte) error {
 	for i := range inputXML {


### PR DESCRIPTION
Query the correct TR-064 action to collect the correct values for max downstream and upstream. 

```
OK - Max Upstream: 36.39 Mbit/s | 'upstream_max'=36.393000;;;;

OK - Max Downstream: 116.80 Mbit/s | 'downstream_max'=116.797000;;;;
```

![image](https://user-images.githubusercontent.com/18580278/94361354-e5d4b300-00b3-11eb-9e34-c539977e9f3e.png)

**Important:**

Since the correct values for the max down-/upstream are stored in a different TR-064 action on cable boxes it is now necessary to define the `--modelgroup` parameter for cable boxes.

```
$ ./check_fritz --password secret -m downstream_max --modelgroup cable
OK - Max Downstream: 130.47 Mbit/s | 'downstream_max'=130.465000;;;;
```

**TODO**
- [x] fix method `downstream_usage`
- [x] fix method `upstream_usage`
- [x] update documentation / entry for updating documentation

fixes #72 
fixes #96 