### PR TITLE
Fix --modelgroup parameter alias not working

### DIFF
--- a/cmd/check_fritz/main.go
+++ b/cmd/check_fritz/main.go
@@ -245,6 +245,7 @@ func main() {
 				Name:        "modelgroup",
 				Value:       "DSL",
 				DefaultText: "DSL",
+				Aliases:     []string{"M"},
 				Usage:       "Specifies the Fritz!Bpx model group (DSL or Cable).",
 			},
 			&cli.Float64Flag{


### PR DESCRIPTION
The shorthand parameter -M was not recognized.