### PR TITLE
Add missing smart_socketenergy entry to help page

### DIFF
--- a/cmd/check_fritz/main.go
+++ b/cmd/check_fritz/main.go
@@ -289,8 +289,9 @@ METHODS:
 	upstream_current        current upstream,
 	downstream_usage        current downstream usage,
 	upstream_usage          current upstream usage,
-	smart_heatertemperatur    current temperature of a a radiator thermostat (requires AIN),
+	smart_heatertemperatur  current temperature of a a radiator thermostat (requires AIN),
 	smart_socketpower       current power consumption of a socket switch (requires AIN),
+	smart_socketenergy 		Total power consumption of the last year of a socket switch (requires AIN),	
 	smart_status            current smart device status (requires AIN)
 `
 


### PR DESCRIPTION
The smart_socketenergy methods was missing in the --help output.