### PR TITLE
Missing performance data output in connection_status & device_update methods 

### DIFF
--- a/cmd/check_fritz/check_connection.go
+++ b/cmd/check_fritz/check_connection.go
@@ -44,25 +44,29 @@ func CheckConnectionStatus(aI ArgumentInformation) {
 		panic(err)
 	}
 
+	output := ""
+
 	if soapResp.NewConnectionStatus == "Connected" {
-		fmt.Print("OK - Connection Status: " + soapResp.NewConnectionStatus)
+		output = fmt.Sprintf("OK - Connection Status: " + soapResp.NewConnectionStatus)
 
 		if soapResp.NewExternalIPAddress != "" {
-			fmt.Print("; External IP: " + soapResp.NewExternalIPAddress)
+			output += "; External IP: " + soapResp.NewExternalIPAddress
 		}
-
-		fmt.Print("\n")
 
 		GlobalReturnCode = exitOk
 	} else if soapResp.NewConnectionStatus == "" {
-		fmt.Print("UNKNOWN - Connection Status is empty\n")
+		output = fmt.Sprint("UNKNOWN - Connection Status is empty")
 
 		GlobalReturnCode = exitUnknown
 	} else {
-		fmt.Print("CRITICAL - Connection Status: " + soapResp.NewConnectionStatus + "\n")
+		output = fmt.Sprintf("CRITICAL - Connection Status: " + soapResp.NewConnectionStatus)
 
 		GlobalReturnCode = exitCritical
 	}
+
+	perfData := perfdata.CreatePerformanceData("status", float64(GlobalReturnCode), "")
+
+	fmt.Printf("%s %s\n", output, perfData.GetPerformanceDataAsString())
 }
 
 // CheckConnectionUptime checks the uptime of the internet connection

--- a/cmd/check_fritz/check_device.go
+++ b/cmd/check_fritz/check_device.go
@@ -79,11 +79,17 @@ func CheckDeviceUpdate(aI ArgumentInformation) {
 
 	GlobalReturnCode = exitOk
 
+	output := ""
+
 	if state == 0 {
-		fmt.Print("OK - No update available\n")
+		output = fmt.Sprint("OK - No update available")
 	} else {
 		GlobalReturnCode = exitCritical
 
-		fmt.Print("CRITICAL - Update available\n")
+		output = fmt.Sprint("CRITICAL - Update available")
 	}
+
+	perfData := perfdata.CreatePerformanceData("pending_update", float64(state), "")
+
+	fmt.Printf("%s %s\n", output, perfData.GetPerformanceDataAsString())
 }


### PR DESCRIPTION
This adds the missing performance data output for the methods `connection_status` and `device_update`.

# Before

```
$ ./check_fritz -H 192.168.178.1 -p PASSWORD -m connection_status
OK - Connection Status: Connected; External IP: 9.999.999.99

$ ./check_fritz -H 192.168.178.1 -p PASSWORD -m device_update
OK - No update available
```
# After
```
$ ./check_fritz -H 192.168.178.1 -p PASSWORD -m connection_status
OK - Connection Status: Connected; External IP: 9.999.999.99 | 'status'=0.000000;;;;

$ ./check_fritz -H 192.168.178.1 -p PASSWORD -m device_update
OK - No update available | 'pending_update'=0.000000;;;;
```
fixes #102 