### PR TITLE
Fix checksum creation during the build process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Go Build
         run: make build
 
+      - name: Test checksum
+        run: make test-checksum
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Go Build
         run: make build
 
+      - name: Test checksum
+        run: make test-checksum
+
       - name: Create Release Draft
         run: |
           set -x

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,19 @@ clean:
 build:
 	mkdir -p build
 	GOOS=linux GOARCH=amd64 $(BUILD) -o build/$(BINARY).linux.amd64 ./cmd/check_fritz
-	sha256sum build/$(BINARY).linux.amd64 > build/$(BINARY).linux.amd64.sha256
 	GOOS=linux GOARCH=arm64 $(BUILD) -o build/$(BINARY).linux.arm64 ./cmd/check_fritz
-	sha256sum build/$(BINARY).linux.arm64 > build/$(BINARY).linux.arm64.sha256
 	GOOS=linux GOARCH=arm $(BUILD) -o build/$(BINARY).linux.arm ./cmd/check_fritz
-	sha256sum build/$(BINARY).linux.arm > build/$(BINARY).linux.arm.sha256
 	GOOS=windows GOARCH=amd64 $(BUILD) -o build/$(BINARY).windows.amd64.exe ./cmd/check_fritz
-	sha256sum build/$(BINARY).windows.amd64.exe > build/$(BINARY).windows.amd64.exe.sha256
 	GOOS=darwin GOARCH=amd64 $(BUILD) -o build/$(BINARY).darwin.amd64 ./cmd/check_fritz
-	sha256sum build/$(BINARY).darwin.amd64 > build/$(BINARY).darwin.amd64.sha256
+	cd build; sha256sum $(BINARY).linux.amd64 > $(BINARY).linux.amd64.sha256
+	cd build; sha256sum $(BINARY).linux.arm64 > $(BINARY).linux.arm64.sha256
+	cd build; sha256sum $(BINARY).linux.arm > $(BINARY).linux.arm.sha256
+	cd build; sha256sum $(BINARY).windows.amd64.exe > $(BINARY).windows.amd64.exe.sha256
+	cd build; sha256sum $(BINARY).darwin.amd64 > $(BINARY).darwin.amd64.sha256
+
+test-checksum:
+	cd build; sha256sum -c $(BINARY).linux.amd64.sha256
+	cd build; sha256sum -c $(BINARY).linux.arm64.sha256
+	cd build; sha256sum -c $(BINARY).linux.arm.sha256
+	cd build; sha256sum -c $(BINARY).windows.amd64.exe.sha256
+	cd build; sha256sum -c $(BINARY).darwin.amd64.sha256


### PR DESCRIPTION
Create the checksum files without the 'build/' folder prefix. Introduce
a new Makefile target to test the checksum files during the CI process.

fixes #105